### PR TITLE
test: Add pytest test suite for API endpoints

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        env:
+          ANONYMOUS_MODE: "0"
+          ADMIN_USER: "test_admin"
+        run: |
+          pytest tests/ -v --tb=short
+
+      - name: Run tests with coverage
+        if: github.event_name == 'pull_request'
+        run: |
+          pip install pytest-cov
+          pytest tests/ -v --cov=app --cov-report=term-missing --cov-fail-under=50

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -v --tb=short
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::UserWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ transformers>=4.36.0
 
 # Optional: for downloading datasets
 datasets>=2.14.0
+
+# Testing
+pytest>=7.0.0
+httpx>=0.24.0  # Required by FastAPI TestClient

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# NLI Span Labeler Test Suite

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,134 @@
+"""
+Pytest configuration and fixtures for NLI Span Labeler tests.
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Add app directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Set test environment before importing app
+os.environ["ANONYMOUS_MODE"] = "0"
+os.environ["ADMIN_USER"] = "test_admin"
+
+
+@pytest.fixture(scope="session")
+def temp_db_path() -> Generator[Path, None, None]:
+    """Create a temporary database file for the test session."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    yield db_path
+    # Cleanup after all tests
+    if db_path.exists():
+        db_path.unlink()
+
+
+@pytest.fixture(scope="session")
+def app(temp_db_path: Path):
+    """Create FastAPI app with test database."""
+    import app as app_module
+
+    # Override database path
+    app_module.DB_PATH = temp_db_path
+
+    # Initialize database
+    app_module.init_db()
+
+    return app_module.app
+
+
+@pytest.fixture(scope="session")
+def client(app) -> Generator[TestClient, None, None]:
+    """Create test client for the session."""
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def fresh_client(temp_db_path: Path) -> Generator[TestClient, None, None]:
+    """Create a fresh test client with clean database for each test."""
+    import importlib
+    import app as app_module
+
+    # Create new temp db for this test
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        test_db = Path(f.name)
+
+    app_module.DB_PATH = test_db
+    app_module.init_db()
+
+    with TestClient(app_module.app) as c:
+        yield c
+
+    if test_db.exists():
+        test_db.unlink()
+
+
+@pytest.fixture
+def auth_client(client: TestClient) -> Generator[tuple[TestClient, dict], None, None]:
+    """Create authenticated test client with a registered user."""
+    # Register a test user
+    response = client.post("/api/auth/register", json={
+        "username": f"testuser_{os.urandom(4).hex()}",
+        "password": "testpass123",
+        "display_name": "Test User"
+    })
+    assert response.status_code == 200
+    user_data = response.json()
+
+    # Client now has session cookie from registration
+    yield client, user_data
+
+
+@pytest.fixture
+def admin_client(client: TestClient) -> Generator[tuple[TestClient, dict], None, None]:
+    """Create authenticated test client with admin user."""
+    # Register as the admin user (ADMIN_USER env var)
+    response = client.post("/api/auth/register", json={
+        "username": "test_admin",
+        "password": "adminpass123",
+        "display_name": "Test Admin"
+    })
+
+    if response.status_code == 400:
+        # Already registered, login instead
+        response = client.post("/api/auth/login", json={
+            "username": "test_admin",
+            "password": "adminpass123"
+        })
+
+    assert response.status_code == 200
+    user_data = response.json()
+
+    yield client, user_data
+
+
+@pytest.fixture
+def sample_example(admin_client: tuple[TestClient, dict]) -> dict:
+    """Create a sample example in the database for testing."""
+    client, admin = admin_client
+
+    # We need to insert an example directly since there's no API for it
+    import app as app_module
+
+    with app_module.get_db() as conn:
+        cursor = conn.execute("""
+            INSERT INTO examples (dataset, premise, hypothesis, label, idx)
+            VALUES (?, ?, ?, ?, ?)
+        """, ("test_dataset", "The cat sat on the mat.", "The cat is sitting.", "entailment", 0))
+        example_id = cursor.lastrowid
+        conn.commit()
+
+    return {
+        "id": example_id,
+        "dataset": "test_dataset",
+        "premise": "The cat sat on the mat.",
+        "hypothesis": "The cat is sitting.",
+        "label": "entailment"
+    }

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,142 @@
+"""
+Tests for admin endpoints.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+
+class TestAdminAccess:
+    """Tests for admin access control."""
+
+    def test_admin_requires_auth(self, fresh_client: TestClient):
+        """Test admin endpoints require authentication."""
+        response = fresh_client.get("/api/admin/users")
+        assert response.status_code == 401
+
+    def test_admin_requires_admin_role(self, auth_client: tuple[TestClient, dict]):
+        """Test admin endpoints require admin role."""
+        client, user = auth_client
+        # Regular user should be denied
+        if user["role"] != "admin":
+            response = client.get("/api/admin/users")
+            assert response.status_code == 403
+
+
+class TestAdminUsers:
+    """Tests for /api/admin/users endpoint."""
+
+    def test_list_users(self, admin_client: tuple[TestClient, dict]):
+        """Test listing users as admin."""
+        client, admin = admin_client
+        response = client.get("/api/admin/users")
+        assert response.status_code == 200
+        data = response.json()
+        assert "users" in data
+        assert isinstance(data["users"], list)
+
+    def test_update_user_role(self, admin_client: tuple[TestClient, dict]):
+        """Test updating user role as admin."""
+        client, admin = admin_client
+
+        # Create a user to update
+        client.post("/api/auth/register", json={
+            "username": "role_test_user",
+            "password": "password123",
+            "display_name": "Role Test"
+        })
+
+        # Get user list to find the user ID
+        users_response = client.get("/api/admin/users")
+        users = users_response.json()["users"]
+        target_user = next((u for u in users if u["username"] == "role_test_user"), None)
+
+        if target_user:
+            response = client.put(f"/api/admin/users/{target_user['id']}/role", json={
+                "role": "admin"
+            })
+            assert response.status_code == 200
+            data = response.json()
+            assert data["new_role"] == "admin"
+
+
+class TestAdminDashboard:
+    """Tests for /api/admin/dashboard endpoint."""
+
+    def test_dashboard_requires_admin(self, auth_client: tuple[TestClient, dict]):
+        """Test dashboard requires admin role."""
+        client, user = auth_client
+        if user["role"] != "admin":
+            response = client.get("/api/admin/dashboard")
+            assert response.status_code == 403
+
+    def test_dashboard_success(self, admin_client: tuple[TestClient, dict]):
+        """Test getting dashboard metrics."""
+        client, admin = admin_client
+        response = client.get("/api/admin/dashboard")
+        assert response.status_code == 200
+        data = response.json()
+        assert "overview" in data
+        assert "activity" in data
+        assert "datasets" in data
+        assert "annotators" in data
+        assert "quality" in data
+        assert "pools" in data
+
+    def test_dashboard_with_filters(self, admin_client: tuple[TestClient, dict]):
+        """Test dashboard with query parameters."""
+        client, admin = admin_client
+        response = client.get("/api/admin/dashboard", params={
+            "dataset": "test_dataset",
+            "days": 7
+        })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["filters"]["dataset"] == "test_dataset"
+        assert data["filters"]["days"] == 7
+
+
+class TestAdminCalibration:
+    """Tests for /api/admin/calibration endpoint."""
+
+    def test_calibration_requires_admin(self, auth_client: tuple[TestClient, dict]):
+        """Test calibration endpoint requires admin role."""
+        client, user = auth_client
+        if user["role"] != "admin":
+            response = client.get("/api/admin/calibration")
+            assert response.status_code == 403
+
+    def test_calibration_success(self, admin_client: tuple[TestClient, dict]):
+        """Test getting calibration config."""
+        client, admin = admin_client
+        response = client.get("/api/admin/calibration")
+        assert response.status_code == 200
+        data = response.json()
+        assert "enabled" in data
+        assert "test_pool_size" in data
+        assert "annotator_counts" in data
+
+
+class TestExport:
+    """Tests for /api/export endpoint."""
+
+    def test_export_requires_admin(self, auth_client: tuple[TestClient, dict]):
+        """Test export requires admin role."""
+        client, user = auth_client
+        if user["role"] != "admin":
+            response = client.get("/api/export")
+            assert response.status_code == 403
+
+    def test_export_success(self, admin_client: tuple[TestClient, dict]):
+        """Test exporting data."""
+        client, admin = admin_client
+        response = client.get("/api/export")
+        assert response.status_code == 200
+        # Export returns JSON data
+        data = response.json()
+        assert "examples" in data or isinstance(data, list)
+
+    def test_export_with_format(self, admin_client: tuple[TestClient, dict]):
+        """Test export with format parameter."""
+        client, admin = admin_client
+        response = client.get("/api/export", params={"format": "json"})
+        assert response.status_code == 200

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -1,0 +1,170 @@
+"""
+Tests for annotation endpoints.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+
+class TestAnnotate:
+    """Tests for /api/annotate endpoint."""
+
+    def test_annotate_requires_auth(self, fresh_client: TestClient):
+        """Test /api/annotate requires authentication."""
+        response = fresh_client.post("/api/annotate", json={
+            "example_id": 1,
+            "labels": [],
+            "complexity_scores": {}
+        })
+        assert response.status_code == 401
+
+    def test_annotate_missing_example(self, auth_client: tuple[TestClient, dict]):
+        """Test annotating nonexistent example fails."""
+        client, user = auth_client
+        response = client.post("/api/annotate", json={
+            "example_id": 99999,
+            "labels": [],
+            "complexity_scores": {
+                "reasoning": 50,
+                "creativity": 50,
+                "domain_knowledge": 50,
+                "contextual": 50,
+                "constraints": 50,
+                "ambiguity": 50
+            }
+        })
+        assert response.status_code == 404
+
+    def test_annotate_success(self, auth_client: tuple[TestClient, dict], sample_example: dict):
+        """Test successful annotation."""
+        client, user = auth_client
+        response = client.post("/api/annotate", json={
+            "example_id": sample_example["id"],
+            "labels": [
+                {"token_index": 0, "label_name": "reasoning", "is_custom": False}
+            ],
+            "complexity_scores": {
+                "reasoning": 75,
+                "creativity": 50,
+                "domain_knowledge": 25,
+                "contextual": 50,
+                "constraints": 50,
+                "ambiguity": 50
+            }
+        })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["example_id"] == sample_example["id"]
+
+    def test_annotate_with_custom_label(self, auth_client: tuple[TestClient, dict], sample_example: dict):
+        """Test annotation with custom label."""
+        client, user = auth_client
+        response = client.post("/api/annotate", json={
+            "example_id": sample_example["id"],
+            "labels": [
+                {"token_index": 0, "label_name": "my_custom_label", "is_custom": True, "color": "#ff0000"}
+            ],
+            "complexity_scores": {
+                "reasoning": 50,
+                "creativity": 50,
+                "domain_knowledge": 50,
+                "contextual": 50,
+                "constraints": 50,
+                "ambiguity": 50
+            }
+        })
+        assert response.status_code == 200
+
+    def test_annotate_invalid_complexity_score(self, auth_client: tuple[TestClient, dict], sample_example: dict):
+        """Test annotation with out-of-range complexity score fails."""
+        client, user = auth_client
+        response = client.post("/api/annotate", json={
+            "example_id": sample_example["id"],
+            "labels": [],
+            "complexity_scores": {
+                "reasoning": 150,  # Out of range (should be 1-100)
+                "creativity": 50,
+                "domain_knowledge": 50,
+                "contextual": 50,
+                "constraints": 50,
+                "ambiguity": 50
+            }
+        })
+        assert response.status_code == 422
+
+
+class TestSkip:
+    """Tests for /api/skip endpoint."""
+
+    def test_skip_requires_auth(self, fresh_client: TestClient):
+        """Test /api/skip requires authentication."""
+        response = fresh_client.post("/api/skip/1")
+        assert response.status_code == 401
+
+    def test_skip_success(self, auth_client: tuple[TestClient, dict], sample_example: dict):
+        """Test successful skip."""
+        client, user = auth_client
+        # Need to lock first
+        client.post(f"/api/lock/{sample_example['id']}")
+        response = client.post(f"/api/skip/{sample_example['id']}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["skipped"] is True
+
+    def test_skip_nonexistent_example(self, auth_client: tuple[TestClient, dict]):
+        """Test skipping nonexistent example fails."""
+        client, user = auth_client
+        response = client.post("/api/skip/99999")
+        assert response.status_code == 404
+
+
+class TestLabels:
+    """Tests for /api/labels endpoint."""
+
+    def test_get_labels_requires_auth(self, fresh_client: TestClient):
+        """Test /api/labels requires authentication."""
+        response = fresh_client.get("/api/labels")
+        assert response.status_code == 401
+
+    def test_get_labels_success(self, auth_client: tuple[TestClient, dict]):
+        """Test getting label schema."""
+        client, user = auth_client
+        response = client.get("/api/labels")
+        assert response.status_code == 200
+        data = response.json()
+        assert "categories" in data
+        assert "difficulty" in data["categories"]
+        assert "nli" in data["categories"]
+
+
+class TestAgreement:
+    """Tests for agreement endpoints."""
+
+    def test_agreement_stats_requires_auth(self, fresh_client: TestClient):
+        """Test /api/agreement/stats requires authentication."""
+        response = fresh_client.get("/api/agreement/stats")
+        assert response.status_code == 401
+
+    def test_agreement_stats_success(self, auth_client: tuple[TestClient, dict]):
+        """Test getting agreement statistics."""
+        client, user = auth_client
+        response = client.get("/api/agreement/stats")
+        assert response.status_code == 200
+        data = response.json()
+        assert "total_examples_with_agreement" in data
+        assert "pools" in data
+
+    def test_pools_requires_auth(self, fresh_client: TestClient):
+        """Test /api/pools requires authentication."""
+        response = fresh_client.get("/api/pools")
+        assert response.status_code == 401
+
+    def test_pools_success(self, auth_client: tuple[TestClient, dict]):
+        """Test getting pool status."""
+        client, user = auth_client
+        response = client.get("/api/pools")
+        assert response.status_code == 200
+        data = response.json()
+        assert "zero_entry" in data
+        assert "building" in data
+        assert "test" in data

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,162 @@
+"""
+Tests for authentication endpoints.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+
+class TestRegistration:
+    """Tests for /api/auth/register endpoint."""
+
+    def test_register_success(self, fresh_client: TestClient):
+        """Test successful user registration."""
+        response = fresh_client.post("/api/auth/register", json={
+            "username": "newuser",
+            "password": "password123",
+            "display_name": "New User"
+        })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["username"] == "newuser"
+        assert data["display_name"] == "New User"
+        assert data["role"] == "annotator"
+        assert "session_token" not in data  # Should be in cookie, not body
+
+    def test_register_duplicate_username(self, fresh_client: TestClient):
+        """Test registration with duplicate username fails."""
+        # First registration
+        fresh_client.post("/api/auth/register", json={
+            "username": "dupuser",
+            "password": "password123",
+            "display_name": "First User"
+        })
+        # Second registration with same username
+        response = fresh_client.post("/api/auth/register", json={
+            "username": "dupuser",
+            "password": "differentpass",
+            "display_name": "Second User"
+        })
+        assert response.status_code == 400
+        assert "already exists" in response.json()["detail"].lower()
+
+    def test_register_short_password(self, fresh_client: TestClient):
+        """Test registration with short password fails."""
+        response = fresh_client.post("/api/auth/register", json={
+            "username": "shortpass",
+            "password": "abc",
+            "display_name": "Short Pass"
+        })
+        assert response.status_code == 422  # Validation error
+
+    def test_register_empty_username(self, fresh_client: TestClient):
+        """Test registration with empty username fails."""
+        response = fresh_client.post("/api/auth/register", json={
+            "username": "",
+            "password": "password123",
+            "display_name": "Empty User"
+        })
+        assert response.status_code == 422
+
+    def test_register_admin_user(self, fresh_client: TestClient):
+        """Test that ADMIN_USER env var grants admin role."""
+        response = fresh_client.post("/api/auth/register", json={
+            "username": "test_admin",  # Matches ADMIN_USER env var
+            "password": "adminpass",
+            "display_name": "Admin"
+        })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["role"] == "admin"
+
+
+class TestLogin:
+    """Tests for /api/auth/login endpoint."""
+
+    def test_login_success(self, fresh_client: TestClient):
+        """Test successful login."""
+        # Register first
+        fresh_client.post("/api/auth/register", json={
+            "username": "logintest",
+            "password": "password123",
+            "display_name": "Login Test"
+        })
+        # Clear cookies
+        fresh_client.cookies.clear()
+        # Login
+        response = fresh_client.post("/api/auth/login", json={
+            "username": "logintest",
+            "password": "password123"
+        })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["username"] == "logintest"
+
+    def test_login_wrong_password(self, fresh_client: TestClient):
+        """Test login with wrong password fails."""
+        # Register
+        fresh_client.post("/api/auth/register", json={
+            "username": "wrongpass",
+            "password": "correctpass",
+            "display_name": "Wrong Pass"
+        })
+        fresh_client.cookies.clear()
+        # Login with wrong password
+        response = fresh_client.post("/api/auth/login", json={
+            "username": "wrongpass",
+            "password": "wrongpassword"
+        })
+        assert response.status_code == 401
+
+    def test_login_nonexistent_user(self, fresh_client: TestClient):
+        """Test login with nonexistent user fails."""
+        response = fresh_client.post("/api/auth/login", json={
+            "username": "ghostuser",
+            "password": "password123"
+        })
+        assert response.status_code == 401
+
+
+class TestLogout:
+    """Tests for /api/auth/logout endpoint."""
+
+    def test_logout_success(self, auth_client: tuple[TestClient, dict]):
+        """Test successful logout."""
+        client, user = auth_client
+        response = client.post("/api/auth/logout")
+        assert response.status_code == 200
+        assert response.json()["message"] == "Logged out"
+
+    def test_logout_clears_session(self, auth_client: tuple[TestClient, dict]):
+        """Test that logout clears the session."""
+        client, user = auth_client
+        # Verify we're logged in
+        me_response = client.get("/api/me")
+        assert me_response.status_code == 200
+
+        # Logout
+        client.post("/api/auth/logout")
+
+        # Clear cookies (simulate browser behavior)
+        client.cookies.clear()
+
+        # Verify we're logged out
+        me_response = client.get("/api/me")
+        assert me_response.status_code == 401
+
+
+class TestMe:
+    """Tests for /api/me endpoint."""
+
+    def test_me_authenticated(self, auth_client: tuple[TestClient, dict]):
+        """Test /api/me returns user info when authenticated."""
+        client, user = auth_client
+        response = client.get("/api/me")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["username"] == user["username"]
+        assert data["display_name"] == user["display_name"]
+
+    def test_me_unauthenticated(self, fresh_client: TestClient):
+        """Test /api/me returns 401 when not authenticated."""
+        response = fresh_client.get("/api/me")
+        assert response.status_code == 401

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,146 @@
+"""
+Tests for example-related endpoints.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+
+class TestGetNext:
+    """Tests for /api/next endpoint."""
+
+    def test_next_requires_auth(self, fresh_client: TestClient):
+        """Test /api/next requires authentication."""
+        response = fresh_client.get("/api/next")
+        assert response.status_code == 401
+
+    def test_next_empty_database(self, auth_client: tuple[TestClient, dict]):
+        """Test /api/next returns 404 when no examples exist."""
+        client, user = auth_client
+        response = client.get("/api/next")
+        # No examples loaded yet
+        assert response.status_code == 404
+
+    def test_next_with_examples(self, auth_client: tuple[TestClient, dict], sample_example: dict):
+        """Test /api/next returns an example when available."""
+        client, user = auth_client
+        response = client.get("/api/next")
+        assert response.status_code == 200
+        data = response.json()
+        assert "id" in data
+        assert "premise" in data
+        assert "hypothesis" in data
+        assert "tokens" in data
+
+    def test_next_with_dataset_filter(self, auth_client: tuple[TestClient, dict], sample_example: dict):
+        """Test /api/next respects dataset filter."""
+        client, user = auth_client
+        # Request non-existent dataset
+        response = client.get("/api/next", params={"dataset": "nonexistent"})
+        assert response.status_code == 404
+
+        # Request correct dataset
+        response = client.get("/api/next", params={"dataset": "test_dataset"})
+        assert response.status_code == 200
+
+
+class TestGetExample:
+    """Tests for /api/example/{id} endpoint."""
+
+    def test_get_example_requires_auth(self, fresh_client: TestClient):
+        """Test /api/example/{id} requires authentication."""
+        response = fresh_client.get("/api/example/1")
+        assert response.status_code == 401
+
+    def test_get_example_not_found(self, auth_client: tuple[TestClient, dict]):
+        """Test /api/example/{id} returns 404 for nonexistent example."""
+        client, user = auth_client
+        response = client.get("/api/example/99999")
+        assert response.status_code == 404
+
+    def test_get_example_success(self, auth_client: tuple[TestClient, dict], sample_example: dict):
+        """Test /api/example/{id} returns example details."""
+        client, user = auth_client
+        response = client.get(f"/api/example/{sample_example['id']}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == sample_example["id"]
+        assert data["premise"] == sample_example["premise"]
+        assert data["hypothesis"] == sample_example["hypothesis"]
+        assert "tokens" in data
+
+
+class TestStats:
+    """Tests for /api/stats endpoint."""
+
+    def test_stats_requires_auth(self, fresh_client: TestClient):
+        """Test /api/stats requires authentication."""
+        response = fresh_client.get("/api/stats")
+        assert response.status_code == 401
+
+    def test_stats_success(self, auth_client: tuple[TestClient, dict]):
+        """Test /api/stats returns statistics."""
+        client, user = auth_client
+        response = client.get("/api/stats")
+        assert response.status_code == 200
+        data = response.json()
+        assert "total_examples" in data
+        assert "annotated_examples" in data
+        assert "datasets" in data
+
+
+class TestDatasets:
+    """Tests for /api/datasets endpoint."""
+
+    def test_datasets_requires_auth(self, fresh_client: TestClient):
+        """Test /api/datasets requires authentication."""
+        response = fresh_client.get("/api/datasets")
+        assert response.status_code == 401
+
+    def test_datasets_success(self, auth_client: tuple[TestClient, dict], sample_example: dict):
+        """Test /api/datasets returns dataset list."""
+        client, user = auth_client
+        response = client.get("/api/datasets")
+        assert response.status_code == 200
+        data = response.json()
+        assert "datasets" in data
+        assert "test_dataset" in data["datasets"]
+
+
+class TestLocking:
+    """Tests for example locking endpoints."""
+
+    def test_lock_acquire_requires_auth(self, fresh_client: TestClient):
+        """Test lock acquire requires authentication."""
+        response = fresh_client.post("/api/lock/1")
+        assert response.status_code == 401
+
+    def test_lock_acquire_success(self, auth_client: tuple[TestClient, dict], sample_example: dict):
+        """Test successful lock acquisition."""
+        client, user = auth_client
+        response = client.post(f"/api/lock/{sample_example['id']}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["locked"] is True
+        assert data["example_id"] == sample_example["id"]
+
+    def test_lock_release_success(self, auth_client: tuple[TestClient, dict], sample_example: dict):
+        """Test successful lock release."""
+        client, user = auth_client
+        # Acquire lock
+        client.post(f"/api/lock/{sample_example['id']}")
+        # Release lock
+        response = client.delete(f"/api/lock/{sample_example['id']}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["released"] is True
+
+    def test_lock_extend(self, auth_client: tuple[TestClient, dict], sample_example: dict):
+        """Test lock extension."""
+        client, user = auth_client
+        # Acquire lock
+        client.post(f"/api/lock/{sample_example['id']}")
+        # Extend lock
+        response = client.put(f"/api/lock/{sample_example['id']}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["extended"] is True


### PR DESCRIPTION
## Summary

- Add `tests/` directory with pytest fixtures and test files
- Add pytest and httpx dependencies to requirements.txt
- Add pytest.ini configuration
- Add GitHub Actions workflow for CI on push/PR

## Test Coverage

| Category | Endpoints |
|----------|-----------|
| Authentication | register, login, logout, /api/me |
| Examples | /api/next, /api/example/{id}, locking |
| Annotation | /api/annotate, /api/skip, /api/labels |
| Admin | users, dashboard, calibration, export |
| Agreement | stats, pools |

## Files Added

- `tests/conftest.py` - Fixtures for test client, auth, sample data
- `tests/test_auth.py` - Authentication endpoint tests
- `tests/test_examples.py` - Example and locking tests
- `tests/test_annotation.py` - Annotation workflow tests
- `tests/test_admin.py` - Admin endpoint tests
- `.github/workflows/test.yml` - CI workflow
- `pytest.ini` - Pytest configuration

## Test Plan

- [ ] Install dependencies: `pip install -r requirements.txt`
- [ ] Run tests: `pytest tests/ -v`
- [ ] Verify CI workflow triggers on PR

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)