### PR TITLE
Implement tiered annotation system - Tier 0 automatic labels (#45)

### DIFF
--- a/app.py
+++ b/app.py
@@ -100,6 +100,50 @@ TRAINING_MIN_EXAMPLES = int(os.environ.get("TRAINING_MIN_EXAMPLES", "5"))  # Gol
 CONTROVERSIAL_THRESHOLD = float(os.environ.get("CONTROVERSIAL_THRESHOLD", "0.5"))  # Auto-flag when agreement below this
 
 # ============================================================================
+# Tiered Annotation System
+# ============================================================================
+
+# Tier 0: Fully automatic labels (computed deterministically)
+TIER0_WORDLISTS = {
+    "negation": {
+        "not", "no", "never", "nobody", "nothing", "nowhere", "neither", "none",
+        "n't", "cannot", "can't", "won't", "don't", "doesn't", "didn't", "isn't",
+        "aren't", "wasn't", "weren't", "hasn't", "haven't", "hadn't", "without",
+        "lack", "lacking", "fail", "failed", "refuse", "refused"
+    },
+    "quantifier": {
+        "all", "every", "each", "any", "some", "most", "many", "few", "several",
+        "both", "none", "no", "half", "majority", "minority", "numerous", "countless"
+    },
+    "modal": {
+        "might", "may", "could", "would", "should", "must", "can", "will", "shall", "ought"
+    },
+    "conditional": {
+        "if", "unless", "when", "whenever", "provided", "assuming", "suppose",
+        "supposing", "whether", "in case", "as long as"
+    },
+    "temporal": {
+        "before", "after", "during", "while", "when", "until", "since", "always",
+        "never", "sometimes", "often", "rarely", "occasionally", "frequently",
+        "constantly", "already", "yet", "still", "now", "then", "soon", "later",
+        "earlier", "recently", "formerly", "previously"
+    },
+    "causal": {
+        "because", "since", "therefore", "thus", "hence", "consequently", "so",
+        "as a result", "due to", "owing to", "caused", "causes", "causing",
+        "leads to", "results in"
+    }
+}
+
+# Tier 1: Weak supervision labels (auto-generated, spot-checked)
+# Requires NLTK WordNet for semantic relations
+TIER1_LABELS = ["hypernym", "hyponym", "synonym", "antonym", "numeric_mismatch", "entity_alignment"]
+
+# Tier 1 configuration
+TIER1_QUALITY_SAMPLE_RATE = float(os.environ.get("TIER1_QUALITY_SAMPLE_RATE", "0.05"))  # 5% spot-check rate
+TIER1_MIN_PRECISION = float(os.environ.get("TIER1_MIN_PRECISION", "0.90"))  # 90% precision threshold
+
+# ============================================================================
 # Label Schema Configuration
 # ============================================================================
 
@@ -325,8 +369,134 @@ def tokenize_text(text: str) -> list[dict]:
             "char_end": char_end,
             "is_subword": is_subword,
         })
-    
+
     return words
+
+
+# ============================================================================
+# Tier 0: Automatic Label Computation
+# ============================================================================
+
+def compute_tier0_labels(premise: str, hypothesis: str, premise_tokens: list[dict], hypothesis_tokens: list[dict]) -> dict:
+    """
+    Compute Tier 0 automatic labels for an example.
+
+    Returns dict mapping label_name -> {premise: [indices], hypothesis: [indices]}
+    """
+    result = {}
+
+    # Get token texts (lowercase for matching)
+    premise_texts = [t["text"].lower() for t in premise_tokens]
+    hypothesis_texts = [t["text"].lower() for t in hypothesis_tokens]
+
+    # Token alignment labels
+    premise_set = set(premise_texts)
+    hypothesis_set = set(hypothesis_texts)
+
+    # aligned_tokens: tokens appearing in both
+    result["aligned_tokens"] = {
+        "premise": [i for i, t in enumerate(premise_texts) if t in hypothesis_set],
+        "hypothesis": [i for i, t in enumerate(hypothesis_texts) if t in premise_set]
+    }
+
+    # premise_only: tokens only in premise
+    result["premise_only"] = {
+        "premise": [i for i, t in enumerate(premise_texts) if t not in hypothesis_set],
+        "hypothesis": []
+    }
+
+    # hypothesis_only: tokens only in hypothesis
+    result["hypothesis_only"] = {
+        "premise": [],
+        "hypothesis": [i for i, t in enumerate(hypothesis_texts) if t not in premise_set]
+    }
+
+    # Wordlist-based detection
+    for label_name, wordlist in TIER0_WORDLISTS.items():
+        premise_matches = []
+        hypothesis_matches = []
+
+        for i, token in enumerate(premise_texts):
+            # Check exact match or if token contains any wordlist entry
+            if token in wordlist:
+                premise_matches.append(i)
+            else:
+                # Check for contractions and multi-word entries
+                for word in wordlist:
+                    if word in token or token.endswith(word):
+                        premise_matches.append(i)
+                        break
+
+        for i, token in enumerate(hypothesis_texts):
+            if token in wordlist:
+                hypothesis_matches.append(i)
+            else:
+                for word in wordlist:
+                    if word in token or token.endswith(word):
+                        hypothesis_matches.append(i)
+                        break
+
+        result[label_name] = {
+            "premise": premise_matches,
+            "hypothesis": hypothesis_matches
+        }
+
+    return result
+
+
+def store_auto_spans(conn, example_id: str, auto_labels: dict, tier: int = 0):
+    """Store computed auto-spans in the database."""
+    for label_name, sources in auto_labels.items():
+        for source, indices in sources.items():
+            if indices:  # Only store non-empty spans
+                conn.execute("""
+                    INSERT OR REPLACE INTO auto_spans (example_id, tier, label_name, source, word_indices)
+                    VALUES (?, ?, ?, ?, ?)
+                """, (example_id, tier, label_name, source, json.dumps(indices)))
+
+
+def get_auto_spans(conn, example_id: str) -> dict:
+    """Retrieve computed auto-spans for an example."""
+    rows = conn.execute("""
+        SELECT tier, label_name, source, word_indices
+        FROM auto_spans
+        WHERE example_id = ?
+    """, (example_id,)).fetchall()
+
+    result = {"tier0": {}, "tier1": {}}
+    for row in rows:
+        tier_key = f"tier{row['tier']}"
+        label = row["label_name"]
+        source = row["source"]
+        indices = json.loads(row["word_indices"])
+
+        if label not in result[tier_key]:
+            result[tier_key][label] = {"premise": [], "hypothesis": []}
+        result[tier_key][label][source] = indices
+
+    return result
+
+
+def ensure_auto_spans_computed(conn, example_id: str, premise: str, hypothesis: str) -> dict:
+    """Ensure auto-spans are computed for an example, computing if needed."""
+    # Check if already computed
+    existing = conn.execute(
+        "SELECT example_id FROM auto_spans WHERE example_id = ? LIMIT 1",
+        (example_id,)
+    ).fetchone()
+
+    if existing:
+        return get_auto_spans(conn, example_id)
+
+    # Compute Tier 0 labels
+    premise_tokens = tokenize_text(premise)
+    hypothesis_tokens = tokenize_text(hypothesis)
+
+    auto_labels = compute_tier0_labels(premise, hypothesis, premise_tokens, hypothesis_tokens)
+    store_auto_spans(conn, example_id, auto_labels, tier=0)
+    conn.commit()
+
+    return get_auto_spans(conn, example_id)
 
 
 # ============================================================================
@@ -624,6 +794,37 @@ def init_db():
 
             CREATE INDEX IF NOT EXISTS idx_gold_example ON gold_annotations(example_id);
             CREATE INDEX IF NOT EXISTS idx_training_user ON training_submissions(user_id);
+        """)
+
+        # Create auto_spans table for tiered annotation system (Tier 0 + Tier 1)
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS auto_spans (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                example_id TEXT NOT NULL,
+                tier INTEGER NOT NULL,
+                label_name TEXT NOT NULL,
+                source TEXT NOT NULL,
+                word_indices TEXT NOT NULL,
+                computed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (example_id) REFERENCES examples(id) ON DELETE CASCADE,
+                UNIQUE(example_id, label_name, source)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_auto_spans_example ON auto_spans(example_id);
+            CREATE INDEX IF NOT EXISTS idx_auto_spans_tier ON auto_spans(tier);
+
+            CREATE TABLE IF NOT EXISTS tier1_quality (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                example_id TEXT NOT NULL,
+                label_name TEXT NOT NULL,
+                verified_by INTEGER,
+                is_correct BOOLEAN,
+                verified_at TIMESTAMP,
+                FOREIGN KEY (example_id) REFERENCES examples(id) ON DELETE CASCADE,
+                FOREIGN KEY (verified_by) REFERENCES users(id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_tier1_quality_label ON tier1_quality(label_name);
         """)
 
         # Add training columns to users table if needed
@@ -1585,6 +1786,7 @@ class ExampleResponse(BaseModel):
     existing_scores: Optional[dict] = Field(None, description="Previously saved complexity scores (by current user)")
     lock_until: Optional[str] = Field(None, description="ISO timestamp when the lock on this example expires")
     pool_status: Optional[str] = Field(None, description="Question pool status: test, building, or zero_entry")
+    auto_spans: Optional[dict] = Field(None, description="Auto-computed spans (Tier 0/1) for read-only display")
 
 
 class UserCreate(BaseModel):
@@ -1922,6 +2124,80 @@ async def auth_status():
         "registration_enabled": not ANONYMOUS_MODE,
         "admin_bootstrap_configured": bool(ADMIN_USER)
     }
+
+
+# ============================================================================
+# API Endpoints - Auto Spans (Tiered Annotation)
+# ============================================================================
+
+@app.get(
+    "/api/auto-spans/{example_id}",
+    tags=["Auto Labels"],
+    summary="Get auto-computed spans for an example",
+    description="Retrieve Tier 0 (automatic) and Tier 1 (weak supervision) labels for an example.",
+)
+async def get_example_auto_spans(
+    example_id: str,
+    user: dict = Depends(get_current_user)
+):
+    """Get auto-computed spans for an example."""
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT premise, hypothesis FROM examples WHERE id = ?",
+            (example_id,)
+        ).fetchone()
+
+        if not row:
+            raise HTTPException(404, f"Example not found: {example_id}")
+
+        auto_spans = ensure_auto_spans_computed(conn, example_id, row["premise"], row["hypothesis"])
+        return {"example_id": example_id, "auto_spans": auto_spans}
+
+
+@app.post(
+    "/api/admin/compute-auto-spans",
+    tags=["Admin"],
+    summary="Batch compute auto-spans (admin)",
+    description="Compute Tier 0 auto-spans for all examples or a specific dataset. Admin only.",
+)
+async def admin_compute_auto_spans(
+    dataset: str = Query(None, description="Filter by dataset (compute all if not specified)"),
+    limit: int = Query(1000, description="Maximum examples to process"),
+    admin: dict = Depends(require_admin)
+):
+    """Batch compute Tier 0 auto-spans for examples."""
+    with get_db() as conn:
+        # Find examples without auto-spans
+        query = """
+            SELECT e.id, e.premise, e.hypothesis
+            FROM examples e
+            WHERE e.id NOT IN (SELECT DISTINCT example_id FROM auto_spans)
+        """
+        params = []
+
+        if dataset:
+            query += " AND e.dataset = ?"
+            params.append(dataset)
+
+        query += f" LIMIT {limit}"
+
+        rows = conn.execute(query, params).fetchall()
+        computed = 0
+
+        for row in rows:
+            premise_tokens = tokenize_text(row["premise"])
+            hypothesis_tokens = tokenize_text(row["hypothesis"])
+            auto_labels = compute_tier0_labels(row["premise"], row["hypothesis"], premise_tokens, hypothesis_tokens)
+            store_auto_spans(conn, row["id"], auto_labels, tier=0)
+            computed += 1
+
+        conn.commit()
+
+        return {
+            "computed": computed,
+            "dataset": dataset,
+            "message": f"Computed Tier 0 auto-spans for {computed} examples"
+        }
 
 
 # ============================================================================
@@ -3984,6 +4260,9 @@ async def get_next_example(
         premise_words = tokenize_text(row["premise"])
         hypothesis_words = tokenize_text(row["hypothesis"])
 
+        # Compute/retrieve auto-spans (Tier 0 labels)
+        auto_spans = ensure_auto_spans_computed(conn, row["id"], row["premise"], row["hypothesis"])
+
         return ExampleResponse(
             id=row["id"],
             dataset=row["dataset"],
@@ -3996,7 +4275,8 @@ async def get_next_example(
             existing_labels=existing_labels,
             existing_scores=existing_scores,
             lock_until=lock_until.isoformat() if lock_until else None,
-            pool_status=row["pool_status"]
+            pool_status=row["pool_status"],
+            auto_spans=auto_spans
         )
 
 
@@ -4069,7 +4349,10 @@ async def get_example(
         # Tokenize the texts
         premise_words = tokenize_text(row["premise"])
         hypothesis_words = tokenize_text(row["hypothesis"])
-        
+
+        # Compute/retrieve auto-spans (Tier 0 labels)
+        auto_spans = ensure_auto_spans_computed(conn, row["id"], row["premise"], row["hypothesis"])
+
         return ExampleResponse(
             id=row["id"],
             dataset=row["dataset"],
@@ -4082,7 +4365,8 @@ async def get_example(
             existing_labels=existing_labels,
             existing_scores=existing_scores,
             lock_until=lock_until,
-            pool_status=row["pool_status"]
+            pool_status=row["pool_status"],
+            auto_spans=auto_spans
         )
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -158,3 +158,60 @@ class TestLocking:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "extended"
+
+
+class TestAutoSpans:
+    """Tests for auto-spans (Tier 0/1 automatic labels)."""
+
+    def test_auto_spans_included_in_next(self, auth_client_with_example: tuple[TestClient, dict, dict]):
+        """Test that /api/next includes auto_spans in response."""
+        client, user, example = auth_client_with_example
+        response = client.get("/api/next")
+        assert response.status_code == 200
+        data = response.json()
+        assert "auto_spans" in data
+        assert "tier0" in data["auto_spans"]
+
+    def test_auto_spans_included_in_example(self, auth_client_with_example: tuple[TestClient, dict, dict]):
+        """Test that /api/example/{id} includes auto_spans in response."""
+        client, user, example = auth_client_with_example
+        response = client.get(f"/api/example/{example['id']}")
+        assert response.status_code == 200
+        data = response.json()
+        assert "auto_spans" in data
+        assert "tier0" in data["auto_spans"]
+
+    def test_auto_spans_endpoint(self, auth_client_with_example: tuple[TestClient, dict, dict]):
+        """Test direct /api/auto-spans/{id} endpoint."""
+        client, user, example = auth_client_with_example
+        response = client.get(f"/api/auto-spans/{example['id']}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["example_id"] == example["id"]
+        assert "auto_spans" in data
+        assert "tier0" in data["auto_spans"]
+
+    def test_auto_spans_tier0_labels(self, auth_client_with_example: tuple[TestClient, dict, dict]):
+        """Test that Tier 0 labels are computed correctly."""
+        client, user, example = auth_client_with_example
+        response = client.get(f"/api/auto-spans/{example['id']}")
+        assert response.status_code == 200
+        data = response.json()
+        tier0 = data["auto_spans"]["tier0"]
+
+        # Should have alignment labels
+        expected_labels = ["aligned_tokens", "premise_only", "hypothesis_only"]
+        for label in expected_labels:
+            if label in tier0:
+                assert "premise" in tier0[label] or "hypothesis" in tier0[label]
+
+    def test_auto_spans_requires_auth(self, fresh_client: TestClient):
+        """Test /api/auto-spans requires authentication."""
+        response = fresh_client.get("/api/auto-spans/test_example")
+        assert response.status_code == 401
+
+    def test_auto_spans_not_found(self, auth_client: tuple[TestClient, dict]):
+        """Test /api/auto-spans returns 404 for nonexistent example."""
+        client, user = auth_client
+        response = client.get("/api/auto-spans/nonexistent_example_id")
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary

Implements Tier 0 automatic label computation for the tiered annotation system (#45).

**Backend changes:**
- Add `TIER0_WORDLISTS` configuration for linguistic marker detection (negation, quantifier, modal, conditional, temporal, causal)
- Add `auto_spans` and `tier1_quality` database tables for storing computed labels
- Implement `compute_tier0_labels()` function for automatic span detection:
  - `aligned_tokens`: tokens appearing in both premise and hypothesis
  - `premise_only`/`hypothesis_only`: set difference labels
  - Wordlist-based detection for 6 linguistic categories
- Add `ensure_auto_spans_computed()` for lazy computation on demand
- Add `auto_spans` field to `ExampleResponse` model

**API changes:**
- `/api/next` and `/api/example/{id}` now include `auto_spans` in response
- New `/api/auto-spans/{id}` endpoint for direct access to computed labels
- New `/api/admin/compute-auto-spans` endpoint for batch computation

**Tests:**
- Add 6 new tests for auto-spans functionality (57 total tests passing)

## What's NOT in this PR

- Tier 1 weak supervision (WordNet integration) - requires NLTK dependency discussion
- UI changes to display auto-labels - pending frontend work
- Quality control sampling system - will be added with Tier 1

## Test plan

- [x] All 57 tests passing
- [ ] Verify auto_spans appears in /api/next response
- [ ] Verify /api/auto-spans/{id} returns computed labels
- [ ] Verify /api/admin/compute-auto-spans batch processes examples

Closes part of #45

🤖 Generated with [Claude Code](https://claude.ai/code)