### PR TITLE
Change difficulty sliders from 1-100 to 0-10 scale (#47)

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ Features:
 - Pre-filled labels for difficulty dimensions and NLI relations
 - Custom label creation with unique colors
 - Multiple labels per token visualization
-- Complexity scoring (1-100 scale)
+- Complexity scoring (0-10 scale)
 - SQLite persistence
 - Stats dashboard and export
 - Multi-user support with session-based authentication
@@ -212,7 +212,7 @@ A multi-user annotation tool for Natural Language Inference (NLI) examples with 
 
 - **Span-level annotation**: Select specific tokens in premise/hypothesis pairs
 - **Multiple labels per token**: Annotate tokens with multiple semantic labels
-- **Complexity scoring**: Rate examples on 6 difficulty dimensions (1-100 scale)
+- **Complexity scoring**: Rate examples on 6 difficulty dimensions (0-10 scale)
 - **Multi-user support**: Session-based authentication with per-user annotation tracking
 - **Role-based access**: Admin and annotator roles with protected endpoints
 - **WordPiece tokenization**: Uses ModernBERT tokenizer for model-aligned annotations
@@ -1094,9 +1094,9 @@ def calculate_complexity_agreement(scores: list[dict]) -> float:
         mean_val = sum(values) / len(values)
         mad = sum(abs(v - mean_val) for v in values) / len(values)
         
-        # Normalize to 0-1 scale (max deviation is 50 on a 1-100 scale)
-        # Agreement = 1 - (MAD / 50)
-        dimension_agreement = max(0, 1 - (mad / 50))
+        # Normalize to 0-1 scale (max deviation is 5 on a 0-10 scale)
+        # Agreement = 1 - (MAD / 5)
+        dimension_agreement = max(0, 1 - (mad / 5))
         total_agreement += dimension_agreement
         valid_dimensions += 1
     

--- a/static/index.html
+++ b/static/index.html
@@ -1635,7 +1635,7 @@
 
                     <h3>Complexity Scores</h3>
                     <p>
-                        Rate each example on a scale of <strong>1-100</strong> for six dimensions:
+                        Rate each example on a scale of <strong>0-10</strong> for six dimensions:
                     </p>
                     <ul>
                         <li><strong>Reasoning</strong> - How much logical inference is required?</li>
@@ -1836,7 +1836,7 @@
 
                 <!-- Training Complexity Scores -->
                 <div class="card complexity-section">
-                    <h3 style="margin-bottom: 15px;">Complexity Scores (1-100)</h3>
+                    <h3 style="margin-bottom: 15px;">Complexity Scores (0-10)</h3>
                     <div class="complexity-grid" id="training-complexity-grid"></div>
                 </div>
 
@@ -1911,7 +1911,7 @@
 
             <!-- Complexity Scores Section -->
             <div class="card complexity-section">
-                <h3 style="margin-bottom: 15px;">Complexity Scores (1-100)</h3>
+                <h3 style="margin-bottom: 15px;">Complexity Scores (0-10)</h3>
                 <div class="complexity-grid" id="complexity-grid"></div>
             </div>
 
@@ -2805,10 +2805,10 @@
                     <div class="complexity-label">${dim.label}</div>
                     <div class="complexity-input">
                         <input type="range" id="complexity-range-${dim.key}"
-                               min="1" max="100" value="50"
+                               min="0" max="10" value="0"
                                oninput="syncComplexity('${dim.key}', this.value, 'range')">
                         <input type="number" id="complexity-num-${dim.key}"
-                               min="1" max="100" value="50"
+                               min="0" max="10" value="0"
                                oninput="syncComplexity('${dim.key}', this.value, 'num')">
                     </div>
                 </div>
@@ -2817,7 +2817,7 @@
 
         function syncComplexity(key, value, source) {
             // Clamp value to valid range
-            value = Math.max(1, Math.min(100, parseInt(value) || 50));
+            value = Math.max(0, Math.min(10, parseInt(value) || 0));
 
             const rangeInput = document.getElementById(`complexity-range-${key}`);
             const numInput = document.getElementById(`complexity-num-${key}`);
@@ -2937,12 +2937,12 @@
             activeLabel = null;
             renderLabels();
 
-            // Reset complexity scores to 50
+            // Reset complexity scores to 0 (default on 0-10 scale)
             complexityDimensions.forEach(dim => {
                 const rangeInput = document.getElementById(`complexity-range-${dim.key}`);
                 const numInput = document.getElementById(`complexity-num-${dim.key}`);
-                if (rangeInput) rangeInput.value = 50;
-                if (numInput) numInput.value = 50;
+                if (rangeInput) rangeInput.value = 0;
+                if (numInput) numInput.value = 0;
             });
         }
 
@@ -4454,12 +4454,12 @@
 
         function initTrainingComplexityScores() {
             trainingComplexityScores = {
-                reasoning: 50,
-                creativity: 50,
-                domain_knowledge: 50,
-                contextual: 50,
-                constraints: 50,
-                ambiguity: 50
+                reasoning: 0,
+                creativity: 0,
+                domain_knowledge: 0,
+                contextual: 0,
+                constraints: 0,
+                ambiguity: 0
             };
 
             const grid = document.getElementById('training-complexity-grid');
@@ -4475,9 +4475,9 @@
             grid.innerHTML = dimensions.map(d => `
                 <div class="complexity-item">
                     <label title="${d.desc}">${d.label}</label>
-                    <input type="range" min="1" max="100" value="50"
+                    <input type="range" min="0" max="10" value="0"
                            oninput="updateTrainingScore('${d.key}', this.value)">
-                    <span class="score-value" id="training-score-${d.key}">50</span>
+                    <span class="score-value" id="training-score-${d.key}">0</span>
                 </div>
             `).join('');
         }


### PR DESCRIPTION
## Summary

Per vicethal's feedback on #47 - finer granularity (1-100) isn't needed. Switching to 0-10 scale.

**Changes:**
- Slider inputs: min=0, max=10, default=0
- Reset function: defaults to 0 on new example
- Help text updated to show "0-10"
- Training mode sliders: same changes
- Section headers: "Complexity Scores (0-10)"
- Agreement calculation: max deviation 5 instead of 50 (for normalized agreement score)
- Documentation: updated scale references

**Note on existing data:**
Legacy scores (1-100) will still be stored correctly in the database but will display incorrectly in the UI (e.g., 50 would show as 50, not 5). If there's existing production data, a migration script would divide by 10.

Partial progress on #47

## Test Plan

- [ ] Sliders show 0-10 range
- [ ] New examples default to 0
- [ ] Number inputs clamp to 0-10
- [ ] Help text shows "0-10"
- [ ] Training mode sliders match

🤖 Generated with [Claude Code](https://claude.ai/code)