### PR TITLE
Fix DB path mismatch in download_data.py (#71)

### DIFF
--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -35,7 +35,7 @@ except ImportError:
 
 LABEL_MAP = {0: "entailment", 1: "neutral", 2: "contradiction"}
 OUTPUT_DIR = Path(__file__).parent.parent / "data" / "nli"
-DB_PATH = Path(__file__).parent.parent / "annotations.db"
+DB_PATH = Path(__file__).parent.parent / "labels.db"  # Must match app.py DB_PATH
 DEFAULT_SAMPLE_SIZE = 500
 
 


### PR DESCRIPTION
## Summary
- Change `DB_PATH` from `annotations.db` to `labels.db` in `scripts/download_data.py`
- Aligns with server's database path in `app.py`
- Fixes `--import` flag functionality

## Test plan
- [x] 61 tests passing
- [x] Verified DB_PATH now matches app.py

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)