### PR TITLE
Add MCP server scaffolding with API client and session management (#75)

### DIFF
--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -1,0 +1,7 @@
+"""
+NLI Span Labeler MCP Server
+
+Provides MCP tools for collaborative NLI annotation via chat interfaces.
+"""
+
+__version__ = "0.1.0"

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for running the MCP server as a module."""
+
+from .server import main
+
+if __name__ == "__main__":
+    main()

--- a/mcp_server/api_client.py
+++ b/mcp_server/api_client.py
@@ -1,0 +1,237 @@
+"""
+API client for the NLI Span Labeler backend.
+
+Wraps all HTTP calls to the FastAPI backend, handling authentication
+and response parsing.
+"""
+
+import httpx
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class APIConfig:
+    """Configuration for the API client."""
+    base_url: str = "http://127.0.0.1:8000"
+    username: str = "mcp-annotator"
+    password: str = "mcp-annotator-password"
+    timeout: float = 30.0
+
+
+@dataclass
+class SpanSelection:
+    """A single span selection."""
+    source: str  # "premise" or "hypothesis"
+    word_index: int
+    word_text: str
+    char_start: int
+    char_end: int
+
+
+@dataclass
+class LabelSubmission:
+    """A label with its spans."""
+    label_name: str
+    label_color: str
+    spans: list[SpanSelection] = field(default_factory=list)
+
+
+@dataclass
+class AnnotationSubmission:
+    """Complete annotation submission."""
+    example_id: str
+    labels: list[LabelSubmission] = field(default_factory=list)
+    complexity_scores: Optional[dict] = None
+
+
+class NLIApiClient:
+    """
+    Client for the NLI Span Labeler API.
+
+    Handles authentication via session cookies and provides typed methods
+    for all annotation-related endpoints.
+    """
+
+    def __init__(self, config: Optional[APIConfig] = None):
+        self.config = config or APIConfig()
+        self._client = httpx.Client(
+            base_url=self.config.base_url,
+            timeout=self.config.timeout,
+            follow_redirects=True,
+        )
+        self._authenticated = False
+
+    def _ensure_auth(self) -> None:
+        """Ensure we have a valid session."""
+        if self._authenticated:
+            return
+
+        # Try to register first (will fail if user exists)
+        try:
+            response = self._client.post(
+                "/api/auth/register",
+                json={
+                    "username": self.config.username,
+                    "password": self.config.password,
+                }
+            )
+            if response.status_code == 200:
+                self._authenticated = True
+                return
+        except Exception:
+            pass
+
+        # Fall back to login
+        response = self._client.post(
+            "/api/auth/login",
+            json={
+                "username": self.config.username,
+                "password": self.config.password,
+            }
+        )
+        response.raise_for_status()
+        self._authenticated = True
+
+    def get_auth_status(self) -> dict:
+        """Get authentication status and mode."""
+        response = self._client.get("/api/auth/status")
+        response.raise_for_status()
+        return response.json()
+
+    def get_me(self) -> dict:
+        """Get current user info."""
+        self._ensure_auth()
+        response = self._client.get("/api/me")
+        response.raise_for_status()
+        return response.json()
+
+    def get_next_example(self, dataset: Optional[str] = None) -> Optional[dict]:
+        """
+        Get the next example to annotate.
+
+        Returns None if no examples are available.
+        """
+        self._ensure_auth()
+        params = {}
+        if dataset:
+            params["dataset"] = dataset
+
+        response = self._client.get("/api/next", params=params)
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        return response.json()
+
+    def get_example(self, example_id: str) -> Optional[dict]:
+        """Get a specific example by ID."""
+        self._ensure_auth()
+        response = self._client.get(f"/api/example/{example_id}")
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        return response.json()
+
+    def get_auto_spans(self, example_id: str) -> Optional[dict]:
+        """Get auto-generated spans for an example."""
+        self._ensure_auth()
+        response = self._client.get(f"/api/auto-spans/{example_id}")
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        return response.json()
+
+    def submit_annotation(self, submission: AnnotationSubmission) -> dict:
+        """Submit an annotation for an example."""
+        self._ensure_auth()
+
+        # Convert dataclass to dict
+        payload = {
+            "example_id": submission.example_id,
+            "labels": [
+                {
+                    "label_name": label.label_name,
+                    "label_color": label.label_color,
+                    "spans": [
+                        {
+                            "source": span.source,
+                            "word_index": span.word_index,
+                            "word_text": span.word_text,
+                            "char_start": span.char_start,
+                            "char_end": span.char_end,
+                        }
+                        for span in label.spans
+                    ]
+                }
+                for label in submission.labels
+            ],
+        }
+        if submission.complexity_scores:
+            payload["complexity_scores"] = submission.complexity_scores
+
+        response = self._client.post("/api/label", json=payload)
+        response.raise_for_status()
+        return response.json()
+
+    def skip_example(self, example_id: str) -> dict:
+        """Skip an example."""
+        self._ensure_auth()
+        response = self._client.post(f"/api/skip/{example_id}")
+        response.raise_for_status()
+        return response.json()
+
+    def extend_lock(self, example_id: str) -> dict:
+        """Extend the lock on an example."""
+        self._ensure_auth()
+        response = self._client.post(f"/api/lock/extend/{example_id}")
+        response.raise_for_status()
+        return response.json()
+
+    def release_lock(self, example_id: str) -> dict:
+        """Release the lock on an example."""
+        self._ensure_auth()
+        response = self._client.post(f"/api/lock/release/{example_id}")
+        response.raise_for_status()
+        return response.json()
+
+    def get_stats(self) -> dict:
+        """Get annotation statistics."""
+        response = self._client.get("/api/stats")
+        response.raise_for_status()
+        return response.json()
+
+    def get_datasets(self) -> list[str]:
+        """Get list of available datasets."""
+        response = self._client.get("/api/datasets")
+        response.raise_for_status()
+        return response.json().get("datasets", [])
+
+    def get_labels(self) -> dict:
+        """Get label schema configuration."""
+        response = self._client.get("/api/labels")
+        response.raise_for_status()
+        return response.json()
+
+    def get_reliability_me(self) -> dict:
+        """Get current user's reliability score."""
+        self._ensure_auth()
+        response = self._client.get("/api/reliability/me")
+        response.raise_for_status()
+        return response.json()
+
+    def get_leaderboard(self) -> dict:
+        """Get the reliability leaderboard."""
+        self._ensure_auth()
+        response = self._client.get("/api/reliability/leaderboard")
+        response.raise_for_status()
+        return response.json()
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self._client.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python3
+"""
+NLI Span Labeler MCP Server
+
+Provides tools for collaborative NLI annotation via chat interfaces.
+Uses the FastMCP framework for MCP protocol implementation.
+"""
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from .api_client import APIConfig, NLIApiClient
+from .session import SessionManager
+
+
+# Configuration from environment
+API_BASE_URL = os.environ.get("NLI_API_URL", "http://127.0.0.1:8000")
+API_USERNAME = os.environ.get("NLI_API_USERNAME", "mcp-annotator")
+API_PASSWORD = os.environ.get("NLI_API_PASSWORD", "mcp-annotator-password")
+STATE_FILE = Path(os.environ.get("NLI_STATE_FILE", "nli_session_state.json"))
+
+
+# Initialize MCP server
+mcp = FastMCP(
+    name="nli-span-labeler",
+    instructions="""
+    NLI Span Labeler - Collaborative annotation tools for Natural Language Inference.
+
+    Use these tools to:
+    1. Fetch examples to annotate (get_next_example)
+    2. View current example details (get_current_example)
+    3. Build up annotation through discussion (add_span, set_difficulty)
+    4. Submit completed annotations (submit_annotation)
+    5. Track progress (get_session_stats, get_leaderboard)
+
+    Typical workflow:
+    1. Call get_next_example to fetch a new example
+    2. Discuss with channel participants which spans support the label
+    3. Use add_span to record agreed-upon spans
+    4. Use set_difficulty to record complexity scores
+    5. Call submit_annotation when consensus is reached
+    """
+)
+
+
+# Shared state
+_api_client: Optional[NLIApiClient] = None
+_session_manager: Optional[SessionManager] = None
+
+
+def get_api_client() -> NLIApiClient:
+    """Get or create the API client."""
+    global _api_client
+    if _api_client is None:
+        config = APIConfig(
+            base_url=API_BASE_URL,
+            username=API_USERNAME,
+            password=API_PASSWORD,
+        )
+        _api_client = NLIApiClient(config)
+    return _api_client
+
+
+def get_session() -> SessionManager:
+    """Get or create the session manager."""
+    global _session_manager
+    if _session_manager is None:
+        _session_manager = SessionManager(STATE_FILE)
+    return _session_manager
+
+
+# =============================================================================
+# MCP Tools - Example Fetching
+# =============================================================================
+
+@mcp.tool()
+def get_next_example(dataset: Optional[str] = None) -> dict:
+    """
+    Fetch the next example to annotate.
+
+    Gets an unannotated example from the NLI labeler, automatically acquiring
+    a lock. The example includes premise, hypothesis, gold label, and auto-spans.
+
+    Args:
+        dataset: Optional dataset filter (snli, mnli, anli)
+
+    Returns:
+        Example data with id, premise, hypothesis, tokens, and auto-spans,
+        or error message if no examples available.
+    """
+    client = get_api_client()
+    session = get_session()
+
+    # Use session's dataset filter if none specified
+    if dataset is None:
+        dataset = session.state.active_dataset
+
+    example = client.get_next_example(dataset=dataset)
+    if example is None:
+        return {"error": "No examples available", "dataset_filter": dataset}
+
+    # Store in session
+    session.set_current_example(example)
+
+    return {
+        "id": example["id"],
+        "dataset": example.get("dataset"),
+        "premise": example["premise"],
+        "hypothesis": example["hypothesis"],
+        "gold_label": example.get("gold_label_text", "unknown"),
+        "premise_tokens": _format_tokens(example.get("premise_words", [])),
+        "hypothesis_tokens": _format_tokens(example.get("hypothesis_words", [])),
+        "auto_spans": example.get("auto_spans", {}),
+        "lock_until": example.get("lock_until"),
+    }
+
+
+@mcp.tool()
+def get_current_example() -> dict:
+    """
+    Get the current example being discussed.
+
+    Returns the example that was fetched with get_next_example, along with
+    any annotation progress built up during discussion.
+
+    Returns:
+        Current example data and annotation progress, or error if none active.
+    """
+    session = get_session()
+
+    if session.state.current_example is None:
+        return {"error": "No current example. Use get_next_example first."}
+
+    example = session.state.current_example
+    progress = session.state.progress
+
+    return {
+        "id": example["id"],
+        "premise": example["premise"],
+        "hypothesis": example["hypothesis"],
+        "gold_label": example.get("gold_label_text", "unknown"),
+        "premise_tokens": _format_tokens(example.get("premise_words", [])),
+        "hypothesis_tokens": _format_tokens(example.get("hypothesis_words", [])),
+        "auto_spans": example.get("auto_spans", {}),
+        "pending_labels": progress.labels,
+        "pending_scores": progress.complexity_scores,
+        "edge_case_flags": progress.edge_case_flags,
+    }
+
+
+@mcp.tool()
+def get_example_by_id(example_id: str) -> dict:
+    """
+    Get a specific example by ID.
+
+    Fetches example details without changing the current session example.
+    Useful for reviewing previously seen examples.
+
+    Args:
+        example_id: The example ID to fetch
+
+    Returns:
+        Example data or error if not found.
+    """
+    client = get_api_client()
+    example = client.get_example(example_id)
+
+    if example is None:
+        return {"error": f"Example not found: {example_id}"}
+
+    return {
+        "id": example["id"],
+        "premise": example["premise"],
+        "hypothesis": example["hypothesis"],
+        "gold_label": example.get("gold_label_text", "unknown"),
+        "premise_tokens": _format_tokens(example.get("premise_words", [])),
+        "hypothesis_tokens": _format_tokens(example.get("hypothesis_words", [])),
+        "auto_spans": example.get("auto_spans", {}),
+    }
+
+
+# =============================================================================
+# MCP Tools - Annotation Building
+# =============================================================================
+
+@mcp.tool()
+def add_span(
+    label_name: str,
+    source: str,
+    word_indices: list[int],
+) -> dict:
+    """
+    Add spans to the current annotation.
+
+    Records that specific tokens should be labeled. Call multiple times
+    to build up the annotation through discussion.
+
+    Args:
+        label_name: Label to apply (e.g., "novel_info", "aligned_tokens")
+        source: Either "premise" or "hypothesis"
+        word_indices: List of token indices to label
+
+    Returns:
+        Updated pending labels or error.
+    """
+    session = get_session()
+
+    if session.state.current_example is None:
+        return {"error": "No current example. Use get_next_example first."}
+
+    if source not in ("premise", "hypothesis"):
+        return {"error": "Source must be 'premise' or 'hypothesis'"}
+
+    example = session.state.current_example
+    words_key = f"{source}_words"
+    words = example.get(words_key, [])
+
+    # Validate indices and build spans
+    added = []
+    errors = []
+    for idx in word_indices:
+        if idx < 0 or idx >= len(words):
+            errors.append(f"Invalid index {idx} (max: {len(words) - 1})")
+            continue
+
+        word = words[idx]
+        span = {
+            "source": source,
+            "word_index": idx,
+            "word_text": word.get("text", "").strip(),
+            "char_start": word.get("char_start", 0),
+            "char_end": word.get("char_end", 0),
+        }
+        session.add_span(label_name, span)
+        added.append(idx)
+
+    return {
+        "label": label_name,
+        "source": source,
+        "added_indices": added,
+        "errors": errors if errors else None,
+        "pending_labels": session.state.progress.labels,
+    }
+
+
+@mcp.tool()
+def remove_span(label_name: str, source: str, word_index: int) -> dict:
+    """
+    Remove a span from the current annotation.
+
+    Args:
+        label_name: Label to remove from
+        source: Either "premise" or "hypothesis"
+        word_index: Token index to remove
+
+    Returns:
+        Updated pending labels or error.
+    """
+    session = get_session()
+
+    if session.state.current_example is None:
+        return {"error": "No current example. Use get_next_example first."}
+
+    removed = session.remove_span(label_name, word_index, source)
+
+    return {
+        "removed": removed,
+        "label": label_name,
+        "source": source,
+        "word_index": word_index,
+        "pending_labels": session.state.progress.labels,
+    }
+
+
+@mcp.tool()
+def clear_labels(label_name: Optional[str] = None) -> dict:
+    """
+    Clear pending labels.
+
+    Args:
+        label_name: Specific label to clear, or None to clear all
+
+    Returns:
+        Updated pending labels.
+    """
+    session = get_session()
+
+    if label_name:
+        session.state.progress.labels.pop(label_name, None)
+    else:
+        session.state.progress.labels.clear()
+
+    session._save_state()
+    return {"pending_labels": session.state.progress.labels}
+
+
+@mcp.tool()
+def set_difficulty(
+    reasoning: Optional[int] = None,
+    creativity: Optional[int] = None,
+    domain_knowledge: Optional[int] = None,
+    contextual: Optional[int] = None,
+    constraints: Optional[int] = None,
+    ambiguity: Optional[int] = None,
+) -> dict:
+    """
+    Set difficulty/complexity scores for the current example.
+
+    Scores are 0-10 where higher means more difficult. Only provided
+    scores are updated; omit to keep existing values.
+
+    Args:
+        reasoning: Reasoning complexity (0-10)
+        creativity: Creative thinking required (0-10)
+        domain_knowledge: Domain expertise needed (0-10)
+        contextual: Context dependency (0-10)
+        constraints: Constraint complexity (0-10)
+        ambiguity: Ambiguity level (0-10)
+
+    Returns:
+        Updated pending scores.
+    """
+    session = get_session()
+
+    if session.state.current_example is None:
+        return {"error": "No current example. Use get_next_example first."}
+
+    scores = {
+        "reasoning": reasoning,
+        "creativity": creativity,
+        "domain_knowledge": domain_knowledge,
+        "contextual": contextual,
+        "constraints": constraints,
+        "ambiguity": ambiguity,
+    }
+
+    errors = []
+    for dim, score in scores.items():
+        if score is not None:
+            if not 0 <= score <= 10:
+                errors.append(f"{dim}: must be 0-10, got {score}")
+            else:
+                session.set_complexity_score(dim, score)
+
+    return {
+        "pending_scores": session.state.progress.complexity_scores,
+        "errors": errors if errors else None,
+    }
+
+
+@mcp.tool()
+def add_edge_case_flag(flag: str) -> dict:
+    """
+    Flag the current example as an edge case.
+
+    Common flags: ambiguous, multi-interpretation, annotator-disagreement,
+    requires-world-knowledge, linguistic-edge-case
+
+    Args:
+        flag: The edge case flag to add
+
+    Returns:
+        Updated edge case flags.
+    """
+    session = get_session()
+
+    if session.state.current_example is None:
+        return {"error": "No current example. Use get_next_example first."}
+
+    session.add_edge_case_flag(flag)
+
+    return {"edge_case_flags": session.state.progress.edge_case_flags}
+
+
+# =============================================================================
+# MCP Tools - Submission
+# =============================================================================
+
+@mcp.tool()
+def submit_annotation() -> dict:
+    """
+    Submit the current annotation.
+
+    Submits all pending labels and complexity scores for the current example.
+    Clears the current example and progress on success.
+
+    Returns:
+        Submission result with agreement metrics, or error.
+    """
+    from .api_client import AnnotationSubmission, LabelSubmission, SpanSelection
+
+    session = get_session()
+    client = get_api_client()
+
+    if session.state.current_example is None:
+        return {"error": "No current example. Use get_next_example first."}
+
+    example_id = session.state.current_example_id
+    progress = session.state.progress
+
+    # Build submission
+    labels = []
+    # Default colors for common labels
+    label_colors = {
+        "novel_info": "#4CAF50",
+        "aligned_tokens": "#2196F3",
+        "contradiction": "#F44336",
+        "premise_only": "#FF9800",
+        "hypothesis_only": "#9C27B0",
+    }
+
+    for label_name, spans in progress.labels.items():
+        color = label_colors.get(label_name, "#607D8B")
+        label_spans = [
+            SpanSelection(
+                source=s["source"],
+                word_index=s["word_index"],
+                word_text=s["word_text"],
+                char_start=s["char_start"],
+                char_end=s["char_end"],
+            )
+            for s in spans
+        ]
+        labels.append(LabelSubmission(
+            label_name=label_name,
+            label_color=color,
+            spans=label_spans,
+        ))
+
+    submission = AnnotationSubmission(
+        example_id=example_id,
+        labels=labels,
+        complexity_scores=progress.complexity_scores if progress.complexity_scores else None,
+    )
+
+    result = client.submit_annotation(submission)
+    session.mark_completed()
+
+    return {
+        "status": "submitted",
+        "example_id": example_id,
+        "labels_submitted": len(labels),
+        "agreement": result.get("agreement"),
+        "session_completed": session.state.examples_completed,
+    }
+
+
+@mcp.tool()
+def skip_example(reason: Optional[str] = None) -> dict:
+    """
+    Skip the current example.
+
+    Marks the example as skipped and clears the current session.
+    Optionally record a reason for skipping.
+
+    Args:
+        reason: Optional reason for skipping
+
+    Returns:
+        Skip confirmation.
+    """
+    session = get_session()
+    client = get_api_client()
+
+    if session.state.current_example is None:
+        return {"error": "No current example. Use get_next_example first."}
+
+    example_id = session.state.current_example_id
+
+    if reason:
+        session.add_discussion_note(f"Skipped: {reason}")
+
+    client.skip_example(example_id)
+    session.mark_skipped()
+
+    return {
+        "status": "skipped",
+        "example_id": example_id,
+        "reason": reason,
+        "session_skipped": session.state.examples_skipped,
+    }
+
+
+# =============================================================================
+# MCP Tools - Statistics & Progress
+# =============================================================================
+
+@mcp.tool()
+def get_session_stats() -> dict:
+    """
+    Get current session statistics.
+
+    Returns progress for this annotation session.
+    """
+    session = get_session()
+    return session.get_session_summary()
+
+
+@mcp.tool()
+def get_global_stats() -> dict:
+    """
+    Get global annotation statistics.
+
+    Returns overall stats from the NLI labeler including total examples,
+    annotations, label distribution, etc.
+    """
+    client = get_api_client()
+    return client.get_stats()
+
+
+@mcp.tool()
+def get_leaderboard() -> dict:
+    """
+    Get the annotator reliability leaderboard.
+
+    Shows ranking by reliability score for all annotators.
+    """
+    client = get_api_client()
+    return client.get_leaderboard()
+
+
+@mcp.tool()
+def get_my_reliability() -> dict:
+    """
+    Get the current user's reliability score.
+
+    Shows calibration status and scored annotation count.
+    """
+    client = get_api_client()
+    return client.get_reliability_me()
+
+
+@mcp.tool()
+def get_available_datasets() -> dict:
+    """
+    Get list of available datasets.
+
+    Returns datasets that can be filtered on.
+    """
+    client = get_api_client()
+    datasets = client.get_datasets()
+    return {"datasets": datasets}
+
+
+@mcp.tool()
+def set_dataset_filter(dataset: Optional[str] = None) -> dict:
+    """
+    Set the dataset filter for get_next_example.
+
+    Args:
+        dataset: Dataset to filter by, or None to clear filter
+
+    Returns:
+        Current filter setting.
+    """
+    session = get_session()
+    session.set_dataset_filter(dataset)
+    return {"active_dataset": dataset}
+
+
+@mcp.tool()
+def get_label_schema() -> dict:
+    """
+    Get the label schema configuration.
+
+    Returns available system labels and custom label policy.
+    """
+    client = get_api_client()
+    return client.get_labels()
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+def _format_tokens(words: list[dict]) -> list[dict]:
+    """Format token list for display."""
+    return [
+        {
+            "index": w.get("index", i),
+            "text": w.get("text", "").strip(),
+        }
+        for i, w in enumerate(words)
+    ]
+
+
+# =============================================================================
+# Entry Point
+# =============================================================================
+
+def main():
+    """Run the MCP server."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_server/session.py
+++ b/mcp_server/session.py
@@ -1,0 +1,167 @@
+"""
+Session state management for annotation sessions.
+
+Tracks the current example being discussed and annotation progress.
+"""
+
+import json
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class AnnotationProgress:
+    """Tracks spans and scores being built up during discussion."""
+    labels: dict[str, list[dict]] = field(default_factory=dict)  # label_name -> spans
+    complexity_scores: dict[str, int] = field(default_factory=dict)
+    edge_case_flags: list[str] = field(default_factory=list)
+    discussion_notes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SessionState:
+    """
+    Current annotation session state.
+
+    Persisted to disk so sessions survive restarts.
+    """
+    # Current example being discussed
+    current_example_id: Optional[str] = None
+    current_example: Optional[dict] = None
+
+    # Annotation being built
+    progress: AnnotationProgress = field(default_factory=AnnotationProgress)
+
+    # Session stats
+    examples_completed: int = 0
+    examples_skipped: int = 0
+    session_started: Optional[str] = None
+
+    # Dataset filter (optional)
+    active_dataset: Optional[str] = None
+
+
+class SessionManager:
+    """
+    Manages persistent session state.
+
+    State is saved to a JSON file so it survives server restarts.
+    """
+
+    def __init__(self, state_file: Optional[Path] = None):
+        self.state_file = state_file or Path("session_state.json")
+        self._state: Optional[SessionState] = None
+
+    @property
+    def state(self) -> SessionState:
+        """Get current state, loading from disk if needed."""
+        if self._state is None:
+            self._state = self._load_state()
+        return self._state
+
+    def _load_state(self) -> SessionState:
+        """Load state from disk, or create new."""
+        if self.state_file.exists():
+            try:
+                with open(self.state_file) as f:
+                    data = json.load(f)
+                # Reconstruct nested dataclass
+                progress_data = data.pop("progress", {})
+                state = SessionState(**data)
+                state.progress = AnnotationProgress(**progress_data)
+                return state
+            except Exception:
+                pass
+        return SessionState(session_started=datetime.now().isoformat())
+
+    def _save_state(self) -> None:
+        """Save state to disk."""
+        if self._state is None:
+            return
+        data = asdict(self._state)
+        with open(self.state_file, "w") as f:
+            json.dump(data, f, indent=2)
+
+    def set_current_example(self, example: dict) -> None:
+        """Set the current example being discussed."""
+        self.state.current_example_id = example.get("id")
+        self.state.current_example = example
+        self.state.progress = AnnotationProgress()  # Reset progress
+        self._save_state()
+
+    def clear_current_example(self) -> None:
+        """Clear the current example (after submit/skip)."""
+        self.state.current_example_id = None
+        self.state.current_example = None
+        self.state.progress = AnnotationProgress()
+        self._save_state()
+
+    def add_span(self, label_name: str, span: dict) -> None:
+        """Add a span to the current annotation progress."""
+        if label_name not in self.state.progress.labels:
+            self.state.progress.labels[label_name] = []
+        self.state.progress.labels[label_name].append(span)
+        self._save_state()
+
+    def remove_span(self, label_name: str, word_index: int, source: str) -> bool:
+        """Remove a span from the current annotation progress."""
+        if label_name not in self.state.progress.labels:
+            return False
+        spans = self.state.progress.labels[label_name]
+        for i, span in enumerate(spans):
+            if span.get("word_index") == word_index and span.get("source") == source:
+                spans.pop(i)
+                self._save_state()
+                return True
+        return False
+
+    def set_complexity_score(self, dimension: str, score: int) -> None:
+        """Set a complexity score."""
+        self.state.progress.complexity_scores[dimension] = score
+        self._save_state()
+
+    def add_edge_case_flag(self, flag: str) -> None:
+        """Add an edge case flag."""
+        if flag not in self.state.progress.edge_case_flags:
+            self.state.progress.edge_case_flags.append(flag)
+            self._save_state()
+
+    def add_discussion_note(self, note: str) -> None:
+        """Add a discussion note."""
+        self.state.progress.discussion_notes.append(note)
+        self._save_state()
+
+    def mark_completed(self) -> None:
+        """Mark current example as completed."""
+        self.state.examples_completed += 1
+        self.clear_current_example()
+
+    def mark_skipped(self) -> None:
+        """Mark current example as skipped."""
+        self.state.examples_skipped += 1
+        self.clear_current_example()
+
+    def set_dataset_filter(self, dataset: Optional[str]) -> None:
+        """Set the active dataset filter."""
+        self.state.active_dataset = dataset
+        self._save_state()
+
+    def get_session_summary(self) -> dict:
+        """Get a summary of the current session."""
+        return {
+            "current_example_id": self.state.current_example_id,
+            "has_current_example": self.state.current_example is not None,
+            "pending_labels": list(self.state.progress.labels.keys()),
+            "pending_scores": list(self.state.progress.complexity_scores.keys()),
+            "examples_completed": self.state.examples_completed,
+            "examples_skipped": self.state.examples_skipped,
+            "session_started": self.state.session_started,
+            "active_dataset": self.state.active_dataset,
+        }
+
+    def reset_session(self) -> None:
+        """Reset the session state entirely."""
+        self._state = SessionState(session_started=datetime.now().isoformat())
+        self._save_state()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,6 @@ nltk>=3.8.0
 # Testing
 pytest>=7.0.0
 httpx>=0.24.0  # Required by FastAPI TestClient
+
+# MCP Server
+mcp>=1.0.0


### PR DESCRIPTION
## Summary
- MCP server for collaborative NLI annotation via chat interfaces
- API client wrapper for all NLI labeler endpoints
- Persistent session state management
- 17 tools ready for Frack to implement logic enhancements

## Components

| File | Purpose |
|------|---------|
| `mcp_server/server.py` | FastMCP server with tool definitions |
| `mcp_server/api_client.py` | HTTP client for NLI labeler API |
| `mcp_server/session.py` | Persistent session state (JSON file) |

## Tools Implemented

**Example Fetching:**
- `get_next_example` - Fetch and lock next example
- `get_current_example` - View current example + progress
- `get_example_by_id` - Fetch specific example

**Annotation Building:**
- `add_span` - Add token spans to labels
- `remove_span` - Remove specific span
- `clear_labels` - Clear pending labels
- `set_difficulty` - Set complexity scores (0-10)
- `add_edge_case_flag` - Flag edge cases

**Submission:**
- `submit_annotation` - Submit completed annotation
- `skip_example` - Skip with optional reason

**Statistics:**
- `get_session_stats` - Current session progress
- `get_global_stats` - Overall annotation stats
- `get_leaderboard` - Reliability rankings
- `get_my_reliability` - User's calibration status

**Configuration:**
- `get_available_datasets` - List datasets
- `set_dataset_filter` - Filter by dataset
- `get_label_schema` - Get label configuration

## Configuration

Environment variables:
- `NLI_API_URL` - Backend URL (default: http://127.0.0.1:8000)
- `NLI_API_USERNAME` / `NLI_API_PASSWORD` - Auth credentials
- `NLI_STATE_FILE` - Session state file path

## Test plan
- [x] MCP server imports successfully
- [x] All 17 tools registered
- [x] 61 existing tests passing
- [ ] Integration test with running backend (Frack's domain)

Partial implementation for #75 - scaffolding complete, ready for Frack's tool logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)